### PR TITLE
Added Dokcerfile for rtsp-simple-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+from ubuntu:18.04
+
+USER 0
+
+RUN apt update && apt install ffmpeg -y
+
+# Assuming you have the compiled binary
+COPY ./rtsp-simple-server /usr/bin/rtsp-simple-server
+
+COPY ./rtsp-simple-server.yml /etc/simple_rtsp_server.yaml
+
+RUN chmod +x /usr/bin/rtsp-simple-server
+
+CMD ["/usr/bin/rtsp-simple-server","/etc/simple_rtsp_server.yaml"]


### PR DESCRIPTION
In order to be able to run rtsp server with docker anywhere
The docker build requires pre-built binary of rtsp-simple-server